### PR TITLE
Fix/group submission visibility

### DIFF
--- a/docs/dev-guidelines/ENDPOINT_SUMMARY.md
+++ b/docs/dev-guidelines/ENDPOINT_SUMMARY.md
@@ -313,10 +313,10 @@ File upload/download for student assignment submissions.
 
 | Method | Path | Body | Response | Notes |
 |--------|------|------|----------|-------|
-| GET | `/submission/<assignment_id>/mine` | — | `Submission` or `404` | ✅ Get current student's submission |
-| POST | `/submission/<assignment_id>/mine` | `file` (multipart) | `{ msg, submission }` | ✅ Upload/replace submission |
-| DELETE | `/submission/<assignment_id>/mine` | — | `{ msg }` | ✅ Delete own submission |
-| GET | `/submission/file/<submission_id>` | — | File download | ✅ Download submission file |
+| GET | `/submission/<assignment_id>/mine` | — | `Submission` or `404` | ✅ Get own or group member's submission |
+| POST | `/submission/<assignment_id>/mine` | `file` (multipart) | `{ msg, submission }` | ✅ Upload/replace own or group submission |
+| DELETE | `/submission/<assignment_id>/mine` | — | `{ msg }` | ✅ Delete own or group submission |
+| GET | `/submission/file/<submission_id>` | — | File download | ✅ Download own or group member's file |
 
 ---
 

--- a/flask_backend/api/controllers/submission_controller.py
+++ b/flask_backend/api/controllers/submission_controller.py
@@ -6,7 +6,7 @@ from flask import Blueprint, current_app, jsonify, request, send_from_directory
 from flask_jwt_extended import get_jwt_identity
 from werkzeug.utils import secure_filename
 
-from ..models import Assignment, Submission, User, User_Course, db
+from ..models import Assignment, CourseGroup, Group_Members, Submission, User, User_Course, db
 from .auth_controller import jwt_role_required
 
 bp = Blueprint("submission", __name__, url_prefix="/submission")
@@ -76,6 +76,30 @@ def _ensure_student_enrolled_for_assignment(user: User, assignment: Assignment):
     return User_Course.get(user.id, assignment.courseID) is not None
 
 
+def _get_group_submission(user_id: int, assignment: Assignment):
+    """Return a group member's submission for this assignment, or None.
+
+    Looks up the user's group in the assignment's course and returns the first
+    submission found from any member of that group.
+    """
+    membership = (
+        Group_Members.query
+        .join(CourseGroup, CourseGroup.id == Group_Members.groupID)
+        .filter(Group_Members.userID == user_id, CourseGroup.courseID == assignment.courseID)
+        .first()
+    )
+    if not membership:
+        return None
+
+    group_member_ids = [
+        m.userID for m in Group_Members.query.filter_by(groupID=membership.groupID).all()
+    ]
+    return Submission.query.filter(
+        Submission.assignmentID == assignment.id,
+        Submission.studentID.in_(group_member_ids),
+    ).first()
+
+
 @bp.route("/<int:assignment_id>/mine", methods=["GET"])
 @jwt_role_required("student", "teacher", "admin")
 def get_my_submission(assignment_id):
@@ -94,6 +118,9 @@ def get_my_submission(assignment_id):
         assignmentID=assignment_id,
         studentID=user.id,
     ).first()
+
+    if not submission and user.is_student():
+        submission = _get_group_submission(user.id, assignment)
 
     return jsonify({"submission": _attachment_payload(submission) if submission else None}), 200
 
@@ -142,12 +169,16 @@ def upload_my_submission(assignment_id):
         studentID=user.id,
     ).first()
 
+    if not submission:
+        submission = _get_group_submission(user.id, assignment)
+
     if submission is None:
         submission = Submission(path=stored_path, studentID=user.id, assignmentID=assignment_id)
         db.session.add(submission)
     else:
         _delete_file_if_exists(submission.path)
         submission.path = stored_path
+        submission.studentID = user.id
 
     db.session.commit()
     return jsonify({"msg": "Attachment saved", "submission": _attachment_payload(submission)}), 200
@@ -171,6 +202,9 @@ def delete_my_submission(assignment_id):
         assignmentID=assignment_id,
         studentID=user.id,
     ).first()
+
+    if not submission:
+        submission = _get_group_submission(user.id, assignment)
 
     if submission is None:
         return jsonify({"msg": "No attachment found"}), 404
@@ -198,10 +232,12 @@ def download_submission_file(submission_id):
         return jsonify({"msg": "User not found"}), 404
 
     if user.is_student():
-        if submission.studentID != user.id:
-            return jsonify({"msg": "Unauthorized"}), 403
         if not _ensure_student_enrolled_for_assignment(user, assignment):
             return jsonify({"msg": "Unauthorized: You do not have access to this class"}), 403
+        if submission.studentID != user.id:
+            group_sub = _get_group_submission(user.id, assignment)
+            if not group_sub or group_sub.id != submission.id:
+                return jsonify({"msg": "Unauthorized"}), 403
 
     file_path = Path(submission.path)
     if not file_path.exists():

--- a/flask_backend/tests/test_submissions.py
+++ b/flask_backend/tests/test_submissions.py
@@ -192,4 +192,215 @@ def test_student_cannot_download_other_students_attachment(test_client, make_adm
 
     download_response = test_client.get(f"/submission/file/{submission_id}")
     assert download_response.status_code == 403
-    assert download_response.json["msg"] == "Unauthorized"
+
+
+# ---------------------------------------------------------------------------
+# Group submission visibility
+# ---------------------------------------------------------------------------
+
+
+def _setup_group_with_two_students(test_client):
+    """Create a course, assignment, group, and two enrolled students in the same group.
+
+    The enroll endpoint auto-creates students with default password "password123".
+    Returns (assignment_id, student_a_email, student_b_email).
+    """
+    student_a = "group.alice@example.com"
+    student_b = "group.bob@example.com"
+
+    # Teacher creates course, enrolls both, creates assignment and group
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": "teacher@example.com", "password": "teacher"}),
+        headers={"Content-Type": "application/json"},
+    )
+
+    class_resp = test_client.post(
+        "/class/create_class",
+        data=json.dumps({"name": "Group Submission Class"}),
+        headers={"Content-Type": "application/json"},
+    )
+    class_id = class_resp.json["class"]["id"]
+
+    test_client.post(
+        "/class/enroll_students",
+        data=json.dumps({
+            "class_id": class_id,
+            "students": f"id,name,email\n1,Alice,{student_a}\n2,Bob,{student_b}",
+        }),
+        headers={"Content-Type": "application/json"},
+    )
+
+    due = (datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=3)).isoformat()
+    assign_resp = test_client.post(
+        "/assignment/create_assignment",
+        data=json.dumps({"courseID": class_id, "name": "Group Assignment", "due_date": due}),
+        headers={"Content-Type": "application/json"},
+    )
+    assignment_id = assign_resp.json["assignment"]["id"]
+
+    group_resp = test_client.post(
+        "/groups/create",
+        data=json.dumps({"courseID": class_id, "name": "Team One"}),
+        headers={"Content-Type": "application/json"},
+    )
+    group_id = group_resp.json["id"]
+
+    # Get enrolled student IDs via class members endpoint
+    members_resp = test_client.post(
+        "/class/members",
+        data=json.dumps({"id": class_id}),
+        headers={"Content-Type": "application/json"},
+    )
+    members = members_resp.json
+    alice_id = next(m["id"] for m in members if m["email"] == student_a)
+    bob_id = next(m["id"] for m in members if m["email"] == student_b)
+
+    test_client.post(
+        "/groups/members/add",
+        data=json.dumps({"groupID": group_id, "userID": alice_id}),
+        headers={"Content-Type": "application/json"},
+    )
+    test_client.post(
+        "/groups/members/add",
+        data=json.dumps({"groupID": group_id, "userID": bob_id}),
+        headers={"Content-Type": "application/json"},
+    )
+
+    return assignment_id, student_a, student_b
+
+
+def test_group_member_can_see_group_submission(test_client, make_admin):
+    """A group member can see a submission uploaded by another group member."""
+    make_admin(email="teacher@example.com", password="teacher", name="Teacher")
+    assignment_id, alice_email, bob_email = _setup_group_with_two_students(test_client)
+
+    # Alice uploads
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": alice_email, "password": "password123"}),
+        headers={"Content-Type": "application/json"},
+    )
+    upload_resp = test_client.post(
+        f"/submission/{assignment_id}/mine",
+        data={"file": (io.BytesIO(b"alice's work"), "report.txt")},
+        content_type="multipart/form-data",
+    )
+    assert upload_resp.status_code == 200
+
+    # Bob can see it
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": bob_email, "password": "password123"}),
+        headers={"Content-Type": "application/json"},
+    )
+    get_resp = test_client.get(f"/submission/{assignment_id}/mine")
+    assert get_resp.status_code == 200
+    assert get_resp.json["submission"] is not None
+    assert get_resp.json["submission"]["filename"].endswith("report.txt")
+
+
+def test_group_member_can_download_group_submission(test_client, make_admin):
+    """A group member can download a file uploaded by another group member."""
+    make_admin(email="teacher@example.com", password="teacher", name="Teacher")
+    assignment_id, alice_email, bob_email = _setup_group_with_two_students(test_client)
+
+    # Alice uploads
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": alice_email, "password": "password123"}),
+        headers={"Content-Type": "application/json"},
+    )
+    upload_resp = test_client.post(
+        f"/submission/{assignment_id}/mine",
+        data={"file": (io.BytesIO(b"downloadable"), "file.txt")},
+        content_type="multipart/form-data",
+    )
+    submission_id = upload_resp.json["submission"]["id"]
+
+    # Bob downloads it
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": bob_email, "password": "password123"}),
+        headers={"Content-Type": "application/json"},
+    )
+    dl_resp = test_client.get(f"/submission/file/{submission_id}")
+    assert dl_resp.status_code == 200
+    assert dl_resp.data == b"downloadable"
+
+
+def test_group_member_can_replace_group_submission(test_client, make_admin):
+    """A group member can replace a submission uploaded by another group member."""
+    make_admin(email="teacher@example.com", password="teacher", name="Teacher")
+    assignment_id, alice_email, bob_email = _setup_group_with_two_students(test_client)
+
+    # Alice uploads
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": alice_email, "password": "password123"}),
+        headers={"Content-Type": "application/json"},
+    )
+    test_client.post(
+        f"/submission/{assignment_id}/mine",
+        data={"file": (io.BytesIO(b"v1"), "draft.txt")},
+        content_type="multipart/form-data",
+    )
+
+    # Bob replaces it
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": bob_email, "password": "password123"}),
+        headers={"Content-Type": "application/json"},
+    )
+    replace_resp = test_client.post(
+        f"/submission/{assignment_id}/mine",
+        data={"file": (io.BytesIO(b"v2"), "final.txt")},
+        content_type="multipart/form-data",
+    )
+    assert replace_resp.status_code == 200
+    assert replace_resp.json["submission"]["filename"].endswith("final.txt")
+
+    # Alice sees the replaced version
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": alice_email, "password": "password123"}),
+        headers={"Content-Type": "application/json"},
+    )
+    get_resp = test_client.get(f"/submission/{assignment_id}/mine")
+    assert get_resp.json["submission"]["filename"].endswith("final.txt")
+
+
+def test_group_member_can_delete_group_submission(test_client, make_admin):
+    """A group member can delete a submission uploaded by another group member."""
+    make_admin(email="teacher@example.com", password="teacher", name="Teacher")
+    assignment_id, alice_email, bob_email = _setup_group_with_two_students(test_client)
+
+    # Alice uploads
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": alice_email, "password": "password123"}),
+        headers={"Content-Type": "application/json"},
+    )
+    test_client.post(
+        f"/submission/{assignment_id}/mine",
+        data={"file": (io.BytesIO(b"to be deleted"), "temp.txt")},
+        content_type="multipart/form-data",
+    )
+
+    # Bob deletes it
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": bob_email, "password": "password123"}),
+        headers={"Content-Type": "application/json"},
+    )
+    del_resp = test_client.delete(f"/submission/{assignment_id}/mine")
+    assert del_resp.status_code == 200
+
+    # Alice sees no submission
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": alice_email, "password": "password123"}),
+        headers={"Content-Type": "application/json"},
+    )
+    get_resp = test_client.get(f"/submission/{assignment_id}/mine")
+    assert get_resp.json["submission"] is None


### PR DESCRIPTION
## Summary
- Group submissions were only visible to the individual who uploaded the file — other group members saw no submission
- Added `_get_group_submission()` helper to `submission_controller.py` that checks group membership via `Group_Members` and `CourseGroup` models
- All four submission endpoints now support group access:
  - **GET** `/mine` — returns group member's submission if user has none
  - **POST** `/mine` — replaces existing group submission (updates `studentID` to new uploader)
  - **DELETE** `/mine` — any group member can remove the group's submission
  - **GET** `/file/<id>` — allows download if requester is in the same group as the submitter

## Test plan
- [x] Added `test_group_member_can_see_group_submission`
- [x] Added `test_group_member_can_download_group_submission`
- [x] Added `test_group_member_can_replace_group_submission`
- [x] Added `test_group_member_can_delete_group_submission`
- [x] All 227 tests passing (223 existing + 4 new)
