### PR TITLE
fix(frontend): prevent timezone drift on assignment date round-trips

### DIFF
--- a/frontend/src/features/assignments/AssignmentDetail.tsx
+++ b/frontend/src/features/assignments/AssignmentDetail.tsx
@@ -8,6 +8,7 @@ import StudentSubmissionCard from "./StudentSubmissionCard";
 import PeerReviewSection from "./PeerReviewSection";
 import GroupReviewSection from "./GroupReviewSection";
 import RubricDisplay from "../reviews/RubricDisplay";
+import { formatDueDate } from "../../util/assignmentDates";
 
 type ReviewTab = "individual" | "group";
 
@@ -80,9 +81,9 @@ export default function AssignmentDetail() {
               </span>
               {(assignment.start_date || assignment.due_date) && (
                 <span className="text-white/80 text-xs">
-                  {assignment.start_date && new Date(assignment.start_date).toLocaleDateString()}
+                  {assignment.start_date && formatDueDate(assignment.start_date)}
                   {assignment.start_date && assignment.due_date && " — "}
-                  {assignment.due_date && new Date(assignment.due_date).toLocaleDateString()}
+                  {assignment.due_date && formatDueDate(assignment.due_date)}
                 </span>
               )}
             </div>

--- a/frontend/src/features/assignments/ManageAssignmentCard.tsx
+++ b/frontend/src/features/assignments/ManageAssignmentCard.tsx
@@ -17,7 +17,10 @@ interface ManageFormData {
 
 function toDatetimeLocal(value?: string) {
   if (!value) return "";
-  const parsed = new Date(value);
+  // Backend returns naive UTC datetimes (no Z suffix).
+  // Append Z so JavaScript parses them as UTC, not local time.
+  const normalized = value.endsWith("Z") || value.includes("+") ? value : value + "Z";
+  const parsed = new Date(normalized);
   if (Number.isNaN(parsed.getTime())) return "";
   return new Date(parsed.getTime() - parsed.getTimezoneOffset() * 60000)
     .toISOString()

--- a/frontend/src/util/assignmentDates.ts
+++ b/frontend/src/util/assignmentDates.ts
@@ -1,11 +1,17 @@
 export type AssignmentStatus = "No due date" | "Upcoming" | "Overdue";
 
+// Backend returns naive UTC datetimes (no Z suffix).
+// Append Z so JavaScript parses them as UTC, not local time.
+function ensureUTC(dateStr: string): string {
+  return dateStr.endsWith("Z") || dateStr.includes("+") ? dateStr : dateStr + "Z";
+}
+
 export function formatDueDate(dueDate?: string): string {
   if (!dueDate) {
     return "No due date";
   }
 
-  const parsed = new Date(dueDate);
+  const parsed = new Date(ensureUTC(dueDate));
   if (Number.isNaN(parsed.getTime())) {
     return "Invalid due date";
   }
@@ -18,7 +24,7 @@ export function getAssignmentStatus(dueDate?: string): AssignmentStatus {
     return "No due date";
   }
 
-  const parsed = new Date(dueDate);
+  const parsed = new Date(ensureUTC(dueDate));
   if (Number.isNaN(parsed.getTime())) {
     return "No due date";
   }


### PR DESCRIPTION
## Summary
- Fix assignment start/due dates shifting by the user's timezone offset on every save
- **Root cause**: Backend returns naive UTC datetimes without a `Z` suffix (e.g. `2026-04-10T17:00:00`). JavaScript's `new Date()` interprets these as local time, so each round-trip shifts the date by the UTC offset (e.g. 7 hours in PDT)
- **Fix**: Append `Z` to backend datetime strings before parsing in three locations:
  - `ManageAssignmentCard.tsx` — `toDatetimeLocal()` (the edit form)
  - `assignmentDates.ts` — `formatDueDate()` and `getAssignmentStatus()` (ClassHome cards)
  - `AssignmentDetail.tsx` — date display (now reuses `formatDueDate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
