### PR TITLE
fix(frontend): enforce mandatory password-change route guard

### DIFF
--- a/frontend/src/features/authentication/AuthProvider.tsx
+++ b/frontend/src/features/authentication/AuthProvider.tsx
@@ -10,8 +10,10 @@ import { BASE_URL } from "../../services/apiBase";
 interface AuthContextType {
   isAuthenticated: boolean;
   isLoading: boolean;
-  login: () => void;
+  mustChangePassword: boolean;
+  login: (mustChangePassword?: boolean) => void;
   logout: () => void;
+  refreshAuth: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -19,36 +21,58 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 function AuthProvider({ children }: { children: ReactNode }) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [mustChangePassword, setMustChangePassword] = useState(false);
+
+  async function refreshAuth() {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`${BASE_URL}/user`, {
+        method: "GET",
+        credentials: "include",
+      });
+
+      if (!res.ok) {
+        setIsAuthenticated(false);
+        setMustChangePassword(false);
+        return;
+      }
+
+      const user = await res.json();
+      setIsAuthenticated(true);
+      setMustChangePassword(Boolean(user?.must_change_password));
+    } catch {
+      setIsAuthenticated(false);
+      setMustChangePassword(false);
+    } finally {
+      setIsLoading(false);
+    }
+  }
 
   useEffect(function () {
-    async function checkAuth() {
-      try {
-        const res = await fetch(`${BASE_URL}/user`, {
-          method: "GET",
-          credentials: "include",
-        });
-
-        setIsAuthenticated(res.ok);
-      } catch {
-        setIsAuthenticated(false);
-      } finally {
-        setIsLoading(false);
-      }
-    }
-
-    checkAuth();
+    refreshAuth();
   }, []);
 
-  function login() {
+  function login(shouldChangePassword = false) {
     setIsAuthenticated(true);
+    setMustChangePassword(shouldChangePassword);
   }
 
   function logout() {
     setIsAuthenticated(false);
+    setMustChangePassword(false);
   }
 
   return (
-    <AuthContext.Provider value={{ isAuthenticated, isLoading, login, logout }}>
+    <AuthContext.Provider
+      value={{
+        isAuthenticated,
+        isLoading,
+        mustChangePassword,
+        login,
+        logout,
+        refreshAuth,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/features/authentication/ChangePasswordForm.tsx
+++ b/frontend/src/features/authentication/ChangePasswordForm.tsx
@@ -2,11 +2,13 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Textbox from '../../ui/Textbox';
 import toast from 'react-hot-toast';
-import { changePassword } from '../../util/api';
+import { changeRequiredPassword } from '../../services/userApi';
+import { useAuth } from './AuthProvider';
 import { pageClasses, blockClasses, innerClasses, inputsClasses, inputChunkClasses } from './LoginForm';
 
 export default function ChangePassword() {
   const navigate = useNavigate();
+  const { refreshAuth } = useAuth();
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -30,7 +32,20 @@ export default function ChangePassword() {
 
     setIsPending(true);
     try {
-      await changePassword(currentPassword, newPassword);
+      await changeRequiredPassword(currentPassword, newPassword);
+
+      const stored = localStorage.getItem('user');
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored);
+          parsed.must_change_password = false;
+          localStorage.setItem('user', JSON.stringify(parsed));
+        } catch {
+          // Ignore malformed local storage payloads.
+        }
+      }
+
+      await refreshAuth();
       toast.success('Password changed successfully! Redirecting...');
       setTimeout(() => navigate('/home'), 2000);
     } catch (err: unknown) {

--- a/frontend/src/features/authentication/LoginForm.tsx
+++ b/frontend/src/features/authentication/LoginForm.tsx
@@ -23,10 +23,10 @@ export default function LoginPage() {
     try {
       const result = await tryLogin(email, password);
       if (result) {
+        login(Boolean(result.must_change_password));
         if (result.must_change_password) {
           navigate('/change-password');
         } else {
-          login();
           navigate('/home');
         }
       } else {

--- a/frontend/src/layouts/ProtectedLayout.tsx
+++ b/frontend/src/layouts/ProtectedLayout.tsx
@@ -6,14 +6,17 @@ import MobileHeader from "../ui/MobileHeader";
 import { useAuth } from "../features/authentication/AuthProvider";
 
 export default function ProtectedLayout() {
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isAuthenticated, isLoading, mustChangePassword } = useAuth();
   const navigate = useNavigate();
 
   useEffect(
     function () {
       if (!isAuthenticated && !isLoading) navigate("/");
+      if (isAuthenticated && !isLoading && mustChangePassword) {
+        navigate("/change-password");
+      }
     },
-    [isAuthenticated, isLoading, navigate]
+    [isAuthenticated, isLoading, mustChangePassword, navigate]
   );
 
   if (isLoading)

--- a/frontend/src/services/userApi.ts
+++ b/frontend/src/services/userApi.ts
@@ -65,5 +65,29 @@ export const deleteAccount = async (password: string) => {
   return response.json();
 };
 
+export const changeRequiredPassword = async (
+  currentPassword: string,
+  newPassword: string
+) => {
+  const response = await fetch(`${BASE_URL}/user/password`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({
+      current_password: currentPassword,
+      new_password: newPassword,
+    }),
+  });
+
+  maybeHandleExpire(response);
+
+  if (!response.ok) {
+    const err = await response.json();
+    throw new Error(err.msg || `Response status: ${response.status}`);
+  }
+
+  return response.json();
+};
+
 export const getUserAvatarUrl = (userId: number) =>
   `${BASE_URL}/user/avatar/${userId}`;


### PR DESCRIPTION
Title:
Fix mandatory password-change bypass via direct URL navigation

Description:
This PR fixes a security and workflow bug where users flagged with must_change_password could bypass the forced password change screen by manually navigating to protected routes (for example, /home).

Root cause:
The app redirected to /change-password immediately after login, but protected route guarding only checked authentication and did not enforce must_change_password after route changes or manual URL edits.

What changed:

Added mustChangePassword state to auth context in [AuthProvider.tsx](vscode-file://vscode-app/c:/Users/Milton/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Added a refreshAuth method that reads the authenticated user from /user and syncs must_change_password.
Updated protected route logic in [ProtectedLayout.tsx](vscode-file://vscode-app/c:/Users/Milton/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to redirect authenticated users with mustChangePassword=true to /change-password.
Updated login flow in [LoginForm.tsx](vscode-file://vscode-app/c:/Users/Milton/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to set must-change-password state immediately after successful login.
Updated [ChangePasswordForm.tsx](vscode-file://vscode-app/c:/Users/Milton/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to use the endpoint that clears must_change_password and refresh auth state before navigating to /home.
Added changeRequiredPassword helper in [userApi.ts](vscode-file://vscode-app/c:/Users/Milton/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Expected behavior after fix:

Users with must_change_password cannot access protected routes until password is changed.
Manual URL edits to bypass /change-password are redirected back to /change-password.
After successful password change, user is allowed into normal protected routes.
Notes:
There is an unrelated pre-existing frontend type issue in [DashboardLayout.tsx:90](vscode-file://vscode-app/c:/Users/Milton/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html) that is not introduced by this PR.