### PR TITLE
chore(test-data): add reusable seed csvs and loader scripts

### DIFF
--- a/docs/test-data/README.md
+++ b/docs/test-data/README.md
@@ -1,0 +1,43 @@
+# Test Seed Data
+
+This folder contains reusable seed data for end-to-end/manual testing.
+
+## Files
+
+- `staff-seed.csv`
+  - 1 admin + 3 teachers with unique names
+  - Columns: `role,name,email,password,must_change_password`
+- `students-21-seed.csv`
+  - 21 students with unique names in the exact CSV format accepted by `/class/enroll_students`
+  - Columns: `id,name,email`
+
+## Quick load workflow (PowerShell)
+
+From repository root:
+
+1. Seed staff users (admin + teachers)
+
+```powershell
+./scripts/seed_staff_from_csv.ps1
+```
+
+Defaults:
+- Admin login used by script: `admin@example.com` / `123456`
+- CSV path: `docs/test-data/staff-seed.csv`
+
+2. Enroll 21 students into a class
+
+```powershell
+./scripts/enroll_students_from_csv.ps1 -ClassId 1
+```
+
+Defaults:
+- Teacher login used by script: `teacher@example.com` / `123456`
+- CSV path: `docs/test-data/students-21-seed.csv`
+
+## Notes
+
+- Scripts are idempotent-ish for repeated runs:
+  - Staff script skips already-existing users.
+  - Enroll script relies on backend duplicate-enrollment checks.
+- Current backend behavior for new roster-created students uses default password `password123`.

--- a/docs/test-data/staff-seed.csv
+++ b/docs/test-data/staff-seed.csv
@@ -1,0 +1,6 @@
+role,name,email,password,must_change_password
+admin,Casey Rowan,qa.admin@example.com,TestPass123!,false
+teacher,Ada Sinclair,teacher1@example.com,TestPass123!,true
+teacher,Jordan Vale,teacher2@example.com,TestPass123!,true
+teacher,Priya Nair,teacher3@example.com,TestPass123!,true
+

--- a/docs/test-data/students-21-seed.csv
+++ b/docs/test-data/students-21-seed.csv
@@ -1,0 +1,22 @@
+id,name,email
+100000001,Mia Chen,student01@example.com
+100000002,Ethan Brooks,student02@example.com
+100000003,Sofia Martinez,student03@example.com
+100000004,Noah Patel,student04@example.com
+100000005,Ava Thompson,student05@example.com
+100000006,Liam Foster,student06@example.com
+100000007,Olivia Reed,student07@example.com
+100000008,Lucas Bennett,student08@example.com
+100000009,Emma Sullivan,student09@example.com
+100000010,Mason Clark,student10@example.com
+100000011,Isla Murphy,student11@example.com
+100000012,Elijah Turner,student12@example.com
+100000013,Harper Nguyen,student13@example.com
+100000014,Logan Wright,student14@example.com
+100000015,Amelia Scott,student15@example.com
+100000016,James Carter,student16@example.com
+100000017,Charlotte Evans,student17@example.com
+100000018,Benjamin Hall,student18@example.com
+100000019,Emily Cooper,student19@example.com
+100000020,Daniel Perez,student20@example.com
+100000021,Grace Kim,student21@example.com

--- a/scripts/enroll_students_from_csv.ps1
+++ b/scripts/enroll_students_from_csv.ps1
@@ -1,0 +1,36 @@
+param(
+    [string]$BaseUrl = "http://localhost:5000",
+    [string]$TeacherEmail = "teacher@example.com",
+    [string]$TeacherPassword = "123456",
+    [int]$ClassId,
+    [string]$CsvPath = "docs/test-data/students-21-seed.csv"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $ClassId) {
+    throw "ClassId is required. Example: -ClassId 1"
+}
+
+if (-not (Test-Path $CsvPath)) {
+    throw "CSV file not found: $CsvPath"
+}
+
+Write-Host "Logging in as teacher..."
+$loginBody = @{ email = $TeacherEmail; password = $TeacherPassword } | ConvertTo-Json
+Invoke-WebRequest -UseBasicParsing -Uri "$BaseUrl/auth/login" -Method Post -Body $loginBody -ContentType "application/json" -SessionVariable Session | Out-Null
+
+$csvText = Get-Content -Path $CsvPath -Raw
+
+$escapedCsv = $csvText `
+    -replace '\\', '\\\\' `
+    -replace '"', '\\"' `
+    -replace "`r`n", '\n' `
+    -replace "`n", '\n'
+
+$payload = "{`"class_id`":$ClassId,`"students`":`"$escapedCsv`"}"
+
+Write-Host "Enrolling students from $CsvPath into class $ClassId..."
+$response = Invoke-RestMethod -Uri "$BaseUrl/class/enroll_students" -Method Post -Body $payload -ContentType "application/json" -WebSession $Session
+Write-Host "Result: $($response.msg)"
+Write-Host "Note: newly created roster users receive default password 'password123' in current backend implementation."

--- a/scripts/seed_staff_from_csv.ps1
+++ b/scripts/seed_staff_from_csv.ps1
@@ -1,0 +1,81 @@
+param(
+    [string]$BaseUrl = "http://localhost:5000",
+    [string]$AdminEmail = "admin@example.com",
+    [string]$AdminPassword = "123456",
+    [string]$CsvPath = "docs/test-data/staff-seed.csv"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-ErrorBody {
+    param([System.Management.Automation.ErrorRecord]$Err)
+
+    try {
+        $response = $Err.Exception.Response
+        if ($null -eq $response) { return $Err.Exception.Message }
+
+        $stream = $response.GetResponseStream()
+        if ($null -eq $stream) { return $Err.Exception.Message }
+
+        $reader = New-Object System.IO.StreamReader($stream)
+        return $reader.ReadToEnd()
+    } catch {
+        return $Err.Exception.Message
+    }
+}
+
+if (-not (Test-Path $CsvPath)) {
+    throw "CSV file not found: $CsvPath"
+}
+
+Write-Host "Logging in as admin..."
+$loginBody = @{ email = $AdminEmail; password = $AdminPassword } | ConvertTo-Json
+Invoke-WebRequest -UseBasicParsing -Uri "$BaseUrl/auth/login" -Method Post -Body $loginBody -ContentType "application/json" -SessionVariable Session | Out-Null
+
+$rows = Import-Csv $CsvPath
+if (-not $rows -or $rows.Count -eq 0) {
+    throw "No rows found in $CsvPath"
+}
+
+$created = 0
+$skipped = 0
+$failed = 0
+
+foreach ($row in $rows) {
+    $role = "$($row.role)".Trim().ToLower()
+    if ($role -notin @("student", "teacher", "admin")) {
+        Write-Host "[SKIP] Invalid role '$role' for $($row.email)"
+        $skipped++
+        continue
+    }
+
+    $mustChange = $false
+    if ("$($row.must_change_password)".Trim().ToLower() -in @("true", "1", "yes", "y")) {
+        $mustChange = $true
+    }
+
+    $payload = @{
+        name = "$($row.name)".Trim()
+        email = "$($row.email)".Trim()
+        password = "$($row.password)"
+        role = $role
+        must_change_password = $mustChange
+    } | ConvertTo-Json
+
+    try {
+        $resp = Invoke-RestMethod -Uri "$BaseUrl/admin/users/create" -Method Post -Body $payload -ContentType "application/json" -WebSession $Session
+        Write-Host "[OK] $($resp.msg)"
+        $created++
+    } catch {
+        $body = Get-ErrorBody $_
+        if ($body -match "already registered") {
+            Write-Host "[SKIP] User already exists: $($row.email)"
+            $skipped++
+        } else {
+            Write-Host "[FAIL] $($row.email): $body"
+            $failed++
+        }
+    }
+}
+
+Write-Host "Done. Created=$created, Skipped=$skipped, Failed=$failed"


### PR DESCRIPTION
# chore(test-data): add reusable seed CSVs and loader scripts

## Summary
This PR adds reusable local test data and PowerShell loaders to speed up end-to-end testing for admin, teacher, and student workflows.

## What’s Included

### Test Seed Data
- staff-seed.csv
- students-21-seed.csv
- README.md

### Loader Scripts
- seed_staff_from_csv.ps1
- enroll_students_from_csv.ps1

## Seed Coverage

### Staff
- 1 admin
- 3 teachers
- Unique names/emails
- Configurable `must_change_password` flag

### Students
- 21 students
- Unique names/emails
- CSV format compatible with `/class/enroll_students`

## Script Behavior

### `seed_staff_from_csv.ps1`
- Logs in as admin
- Creates users via `/admin/users/create`
- Skips already-existing users gracefully

### `enroll_students_from_csv.ps1`
- Logs in as teacher
- Sends roster CSV to `/class/enroll_students`
- Uses explicit JSON string serialization for `students` (avoids PowerShell object-conversion issues)
- Uses `-UseBasicParsing` to avoid interactive parsing prompts

## How to Run

```powershell
# 1) Seed staff users
./scripts/seed_staff_from_csv.ps1

# 2) Enroll 21 students into a class
./scripts/enroll_students_from_csv.ps1 -ClassId 1
```

## Notes
- Designed for repeatable local testing.
- Roster-created students currently receive backend default password `password123` (existing backend behavior).